### PR TITLE
Update for Lasso 9.3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,12 +27,12 @@ Installation
 ### Compile From Source
 
     $> cd where/you/want/the/source/installed/
-    $> git clone https://bitbucket.org/bfad/lspec.git
+    $> git clone https://github.com/bfad/lspec.git
     $> cd lspec
     $> make
     $> make install
 
-_Note: If you're compiling on Mac OS X, you'll need the 10.5 SDK installed. You can follow the instructions [here](http://hints.macworld.com/article.php?story=20110318050811544) to restore the 10.5 SDK to Xcode 4._
+_Note: If you're compiling on Mac OS X, you'll need the 10.5 SDK installed to build a library for all supported versions. You can follow [these instructions](https://github.com/devernay/xcodelegacy) to restore the 10.5 SDK to Xcode 4 and later._
 
 ### Set Your Path
 
@@ -50,16 +50,16 @@ First, create a file named zoo.spec.inc and write a test describing functionalit
                 local(menagerie) = zoo
                 local(num_animals_start) = #menagerie->numberOfAnimals
                 local(num_animals_end)
-                
+
                 #menagerie->addAnimal(animal('Rhino'))
                 #num_animals_end = #menagerie->numberOfAnimals
-                
+
                 expect(#menagerie->hasA('Rhino'))
                 expect(#num_animals_end == 1 + #num_animals_start)
             }
         }
     }
-    
+
 Then run the test and watch it fail.
 
     $> lspec zoo.spec.inc
@@ -77,7 +77,7 @@ Then run the test and watch it fail.
     1 test, 1 failure
 
 Now add the following code to the beginning of zoo.spec.inc. (Usually you would keep the tests in separate files and have them first include the code you are testing.)
-    
+
     define zoo => type {
         data private animals = array
 

--- a/README.markdown
+++ b/README.markdown
@@ -21,8 +21,8 @@ Installation
 ### Pre-compiled Libraries
 
 1. Click the "Downloads" menu option at the top of this page.
-2. Choose the proper download for your platform
-3. Decompress the files and move lspec to `$LASSO9_HOME/bin/` and lspec.so or lspec.dylib into `$LASSO9_HOME/LassoLibraries/`
+2. Choose the proper download for your platform.
+3. Decompress the files and move lspec to `$LASSO9_HOME/bin/` and lspec.so or lspec.dylib into `$LASSO9_HOME/LassoLibraries/`.
 
 ### Compile From Source
 
@@ -68,7 +68,7 @@ Then run the test and watch it fail.
     Failures:
 
         1) Zoo addAnimal inserts an animal into the zoo and increases numberOfAnimals by 1
-           Failure/Error: Unexpcted Error!
+           Failure/Error: Unexpected Error!
                Error Code: -9948
                 Error Msg: Definition Not Found: zoo()
            # 3:9 /Path/To/zoo.spec.inc

--- a/command/lspec
+++ b/command/lspec
@@ -1,23 +1,23 @@
-#!/usr/bin/lasso9
+#!/usr/bin/env lasso9
 
 define usage(exit_status::integer=-1) => {
     local(cmd) = $argv->get(1)->lastComponent
     stdoutnl("\
-usage: " + #cmd + " [options] [file or director paths]
+usage: " + #cmd + " [options] [file or directory paths]
 
     The " + #cmd + " command executes the Lasso code in the specified file or
-    all Lasso files in the specified directory. If no file or directory path is 
+    all Lasso files in the specified directory. If no file or directory path is
     specified, then it tries a relative directory named \"spec\".
     
     When a directory is specified (or when using the default \"spec\" directory),
-    the command executes all files ending in \".spec.inc\" in that directory. Then 
+    the command executes all files ending in \".spec.inc\" in that directory. Then
     it proceeds to do the same thing in any nested directories. (To specify what
     extensions are considered Lasso files, see the \"-exts\" option.)
 
 Options
 -------
     -documentation
-        Output just the group and test descriptions
+        Output just the group and test descriptions.
     
     -exts CSV_EXT_LIST
         Allows for specifying a comma-separated list of file extensions to be
@@ -28,7 +28,7 @@ Options
         Don't use terminal colors for the output.
         
     -h
-        Displays this help and exits"
+        Displays this help and exits."
     )
     sys_exit(#exit_status)
 }
@@ -71,7 +71,7 @@ while(#opts->size > 0) => {
             ? usage
         
         #exts = #opts->get(2)->split(',')->asStaticArray
-        // Since we're deaing with the next item, delete one now (we delete the other later)
+        // Since we're dealing with the next item, delete one now (we delete the other later)
         #opts->remove(1,1)
         
     case
@@ -87,11 +87,11 @@ lspec->formatResults(#mode)
 
 #use_color? lspec->useColor
 
-with path in #paths 
+with path in #paths
 let f = file(#path)
 do {
     if(not #f->exists) => {
-        file_stderr->writeString(error_code_resNotFound + ':' + error_msg_resNotFound + ' - ' + #path)
+        file_stderr->writeString(error_code_resNotFound + ':' + error_msg_resNotFound + ' - ' + #path + sys_eol)
         sys_exit(1)
     }
     #f->isDir? lspec_runDir(dir(#path), #exts)

--- a/command/lspec
+++ b/command/lspec
@@ -45,7 +45,13 @@ define lspec_runDir(d::dir, ext::staticarray=(:'inc')) => {
 }
 
 define lspec_runFile(f::file) => {
-    sourcefile(#f, -autoCollect=false)->invoke
+    protect => {
+        handle_failure => {
+            error_code != error_code_aborted ?
+                stdoutnl('\nError Code: ' + error_code + '\nError Msg: ' + error_msg + '\nError Stack:\n\n' + error_stack + '\n')
+        }
+        sourcefile(#f, -autoCollect=false)->invoke
+    }
 }
 
 // Defaults

--- a/lspec.inc
+++ b/lspec.inc
@@ -33,7 +33,7 @@ define error_code_lspecTestGroupInTest => 102
 define error_msg_lspecTestGroupInTest  => "The test group is in a test block"
 
 define error_code_lspecStopInTestGroup => 103
-define error_msg_lspecStopInTestGroup  => "Can not stop while in a test group"
+define error_msg_lspecStopInTestGroup  => "Cannot stop while in a test group"
     
 define error_code_lspecInvalidResultFormat => 104
 define error_msg_lspecInvalidResultFormat  => "You have specified an invalid result format"
@@ -48,7 +48,7 @@ define error_code_lspecTestGroupHasBeforeAll => 107
 define error_msg_lspecTestGroupHasBeforeAll  => "You have already specified a [beforeAll] block"
 
 define error_code_lspecTestGroupHasAfterAll => 108
-define error_msg_lspecTestGroupHasAfterAll  => "You have already specified a [afterAll] block"
+define error_msg_lspecTestGroupHasAfterAll  => "You have already specified an [afterAll] block"
 
 
 define lspec_testSuite => type {
@@ -110,12 +110,12 @@ define lspec_testSuite => type {
                     'resultsFormat'  = "p",
                     'indentor'       = "    ",
                     'suppressOutput' = false,
-										'colorOutput'    = false,
+                    'colorOutput'    = false,
          )
     // Configuration Options Setters & Getters
     public options => .'options'
     public setOptions(new::map) => {
-        with key in .'options'->keys 
+        with key in .'options'->keys
         do {
             #new->contains(#key)? .'options'->find(#key) = #new->find(#key)
         }
@@ -126,34 +126,33 @@ define lspec_testSuite => type {
     public isOutputSuppressed =>   .options->find('suppressOutput'),
            suppressOutput     => { .options->find('suppressOutput') = true  },
            showOutput         => { .options->find('suppressOutput') = false }
-		
-		public isOutputInColor =>   .options->find(`colorOutput`),
- 		       noColor         => { .options->find(`colorOutput`) = false },
-					 useColor        => { .options->find(`colorOutput`) = true  }
+
+    public isOutputInColor =>   .options->find(`colorOutput`),
+           noColor         => { .options->find(`colorOutput`) = false },
+           useColor        => { .options->find(`colorOutput`) = true  }
            
     public resultsFormat => .options->find('resultsFormat')
     public formatResults(new::string) => {
-        fail_if(not .validFormats->contains(#new), 
+        fail_if(not .validFormats->contains(#new),
             error_code_lspecInvalidResultFormat, error_msg_lspecInvalidResultFormat)
         .options->find('resultsFormat') = #new
     }
-		
-		// Color Stuff
-		data terminalColors = map(
-				`normal`     = decode_base64('Gw==') + '[0m',
-				`boldRed`    = decode_base64('Gw==') + '[1;31;49m',
-				`boldGreen`  = decode_base64('Gw==') + '[1;32;49m',
-				`boldYellow` = decode_base64('Gw==') + '[1;33;49m',
-				`boldCyan`   = decode_base64('Gw==') + '[1;36;49m',
-		)
-		public outputColor(color::string) => {
-			  not .isOutputInColor
-					  ? return ''
+    
+    // Color Stuff
+    data terminalColors = map(
+            `normal`     = decode_base64('Gw==') + '[0m',
+            `boldRed`    = decode_base64('Gw==') + '[1;31;49m',
+            `boldGreen`  = decode_base64('Gw==') + '[1;32;49m',
+            `boldYellow` = decode_base64('Gw==') + '[1;33;49m',
+            `boldCyan`   = decode_base64('Gw==') + '[1;36;49m',
+    )
+    public outputColor(color::string) => {
+        not .isOutputInColor? return ''
 
-			  return string(.'terminalColors'->get(#color))
-		}
-    
-    
+        return string(.'terminalColors'->get(#color))
+    }
+
+
     // Code to add test stuff to lspec test suite
     public addTestGroup(tg::lspec_testGroup) => {
         fail_if(.inTest, error_code_lspecTestGroupInTest, error_msg_lspecTestGroupInTest)
@@ -180,7 +179,6 @@ define lspec_testSuite => type {
     }
     public addBeforeEach(block::capture) => {
         fail_if(not .inTestGroup, error_code_lspecNotInTestGroup, error_msg_lspecNotInTestGroup)
-        
         .getCurrentTestGroup->beforeEach(#block)
     }
     public addAfterAll(block::capture) => {
@@ -189,7 +187,6 @@ define lspec_testSuite => type {
     }
     public addAfterEach(block::capture) => {
         fail_if(not .inTestGroup, error_code_lspecNotInTestGroup, error_msg_lspecNotInTestGroup)
-        
         .getCurrentTestGroup->afterEach(#block)
     }
     
@@ -243,13 +240,13 @@ define lspec_testSuite => type {
         .numFailures++
         
         local(spacer)    = ' ' * (.numFailures->asString->size + 2)
-        local(location)  = (not #error ? #test->failedTestCase->location | #test->location)
+        local(location)  = (not #error? #test->failedTestCase->location | #test->location)
         local(line_num)  = integer(#location->first->split(':')->first)
         local(col_num)   = integer(#location->first->split(':')->second)
         local(code)
         
         if(#error) => {
-            #code = 'Unexpcted Error!'
+            #code = 'Unexpected Error!'
         else
             local(f) = file(#location->second, file_openRead, file_modeLine)
             #f->doWithClose => {
@@ -282,7 +279,8 @@ define lspec_testSuite => type {
         'p' == .resultsFormat? return
         
         local(out) = (.indentor * .currentDepth) + #tg->label
-        .result != '' ? #out = '\n' + #out
+        .result != ''
+            ? #out = '\n' + #out
         .output(#out)
     }
     public output(test::lspec_test) => {
@@ -321,7 +319,7 @@ define lspec_testSuite => type {
 /*
 * Wrapper for the test suite.
 * This allows us to create one universal test suite object per thread. All
-* subsequent methods use this object, and so should users when necessary
+* subsequent methods use this object, and so should users when necessary.
 */
 define lspec => var(_lspec) || $_lspec := lspec_testSuite
 
@@ -417,7 +415,6 @@ define lspec_testGroup => type {
         .currentTest = 0
         .tests->forEach => {
             .currentTest++
-            
             .parentSuite->runCurrentBeforeEach
             #1->run
             .runAfterEaches
@@ -427,7 +424,7 @@ define lspec_testGroup => type {
             .currentGroup++
             .parentSuite->incGroupDepth
             #1->parentGroup = self
-            #1->run 
+            #1->run
             .parentSuite->decGroupDepth
         }
     }
@@ -450,7 +447,7 @@ define lspec_test => type {
            location       => .'location',
            failedTestCase => .'failedTestCase'
     // Setters
-    public failed(test_case::expect)   => {
+    public failed(test_case::expect) => {
         .status = 'fail'
         .failedTestCase = #test_case
     }
@@ -590,7 +587,7 @@ define expect => type {
 }
 
 /*
-* This expect statement expects a null value to be passed into it
+* This expect statement expects a null value to be passed into it.
 */
 define expect->null(value) => {
     not #value->isA(::null)?
@@ -681,7 +678,7 @@ define expect->errorMsg(msg::string) => {
 */
 define expect->error => {
     fail_if(not givenBlock,
-    error_code_missingGivenBlock, error_msg_missingGivenBlock)
+        error_code_missingGivenBlock, error_msg_missingGivenBlock)
 
     local(my_error) = pair(error_code_noerror=error_msg_noerror)
     protect => {
@@ -720,5 +717,6 @@ define expect->stdout(expected::string) => {
     
     local(did_read) = #read_test->readString
     
-    #did_read != #expected? .fail(#expected, #did_read)
+    #did_read != #expected
+        ? .fail(#expected, #did_read)
 }

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CC = gcc
 KERNEL_NAME = $(shell uname -s)
 
 OSX_DEPLOY_VERS = 10.5
-SDK = /Developer/SDKs/MacOSX$(OSX_DEPLOY_VERS).sdk
+SDK = $(shell xcodebuild -version -sdk macosx Path)
 
 ifeq ($(DEBUG),1)
 
@@ -32,7 +32,7 @@ Linux_DLL_EXT = .so
 
 DLL_EXT = $($(KERNEL_NAME)_DLL_EXT)
 
-LASSO9_MODULE_CMD = /usr/bin/lassoc
+LASSO9_MODULE_CMD = $(shell which lassoc)
 
 C_FLAGS = $(DEBUG_FLAGS) -fPIC
 LN_FLAGS = $(DEBUG_FLAGS) $($(KERNEL_NAME)_LN_FLAGS)

--- a/spec/command/lspec.spec.inc
+++ b/spec/command/lspec.spec.inc
@@ -86,6 +86,18 @@ describe('lspec command') => {
             expect('', #test_file->readString)
         }
         
+        it('errors on bad syntax') => {
+            #test_file->doWithClose => {
+                #test_file->writeString("#missing")
+            }
+            
+            local(stdout, stderr) = call_lspec((:#test_file->path))
+            
+            expect(void == #stderr)
+            expect(#stdout->asString->contains('/tmp/lspec.test: The local variable "missing" has not been defined'))
+            expect('#missing', #test_file->readString)
+        }
+        
         it('displays the "no test" summary') => {
             local(expected) = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
             

--- a/spec/command/lspec.spec.inc
+++ b/spec/command/lspec.spec.inc
@@ -87,7 +87,7 @@ describe('lspec command') => {
         }
         
         it('displays the "no test" summary') => {
-            local(expected) = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+            local(expected) = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
             
             local(stdout, stderr) = call_lspec((:#test_file->path))
             
@@ -133,7 +133,7 @@ describe('lspec command') => {
         }
 
         it('displays the "no test" summary') => {
-            local(expected) = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+            local(expected) = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
 
             local(stdout, stderr) = call_lspec((:#test_file1->path, #test_file2->path, #test_file3->path))
 
@@ -171,7 +171,7 @@ describe('lspec command') => {
                 expect("file('" + #test_file->path + "')->openTruncate&close", #test_file->readString)
             }
             it('displays the "no test" summary') => {
-                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
                 local(stdout, stderr) = call_lspec((:#test_dir->path + 'spec'))
                 
                 expect(void == #stderr)
@@ -194,7 +194,7 @@ describe('lspec command') => {
                 expect('', #test_file->readString)
             }
             it('displays the "no test" summary') => {
-                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
                 local(stdout, stderr) = call_lspec((:#test_dir->path + 'spec'))
                 
                 expect(void == #stderr)
@@ -227,7 +227,7 @@ describe('lspec command') => {
                 expect('', #test_file3->readString)
             }
             it('displays the "no test" summary') => {
-                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
                 local(stdout, stderr) = call_lspec((:#test_dir->path + 'spec'))
                 
                 expect(void == #stderr)
@@ -251,7 +251,7 @@ describe('lspec command') => {
                 expect('', #test_file->readString)
             }
             it('displays the "no test" summary') => {
-                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
                 local(stdout, stderr) = call_lspec((:#test_dir->path + 'spec'))
                 
                 expect(void == #stderr)
@@ -282,7 +282,7 @@ describe('lspec command') => {
                 expect('', #test_file3->readString)
             }
             it('displays the "no test" summary') => {
-                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+                local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
                 local(stdout, stderr) = call_lspec((:#test_dir->path + 'spec/sub1', #test_dir->path + 'spec/sub2', #test_dir->path + 'spec/sub3'))
                 
                 expect(void == #stderr)
@@ -312,7 +312,7 @@ describe('lspec command') => {
                     expect('', #test_file3->readString)
                 }
                 it('displays the "no test" summary') => {
-                    local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+                    local(expected)       = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
                     local(stdout, stderr) = call_lspec((:#test_dir->path + 'spec/sub1', #test_dir->path + 'spec/sub2', #test_dir->path + 'spec/sub3'))
                     
                     expect(void == #stderr)
@@ -354,7 +354,7 @@ describe('lspec command') => {
         }
         it("executes all the files with the test extension in the spec folder") => {
             local(cwd)        = dir(io_file_getcwd)
-            local(expected)   = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n'
+            local(expected)   = '\n\nFinished in 0.000000 seconds\n' + $termColor('boldCyan') + '0' + $termColor('normal') + ' tests, ' + $termColor('boldRed') + '0' + $termColor('normal') + ' failures\n\n'
             local(test_file1) = file(#test_dir->path + 'spec/foo1.spec.inc')
             local(test_file2) = file(#test_dir->path + 'spec/foo2.spec.inc')
             local(test_file3) = file(#test_dir->path + 'spec/foo3.expt.inc')
@@ -511,4 +511,3 @@ describe('lspec command') => {
     }
 }
 
-lspec->stop

--- a/spec/command/lspec.spec.inc
+++ b/spec/command/lspec.spec.inc
@@ -22,11 +22,11 @@ define call_lspec(args::staticarray=(:)) => {
 
 
 var(termColor) = map(
-	`normal`     = '' + decode_base64('Gw==') + '[0m',
-	`boldRed`    = '' + decode_base64('Gw==') + '[1;31;49m',
-	`boldGreen`  = '' + decode_base64('Gw==') + '[1;32;49m',
-	`boldYellow` = '' + decode_base64('Gw==') + '[1;33;49m',
-	`boldCyan`   = '' + decode_base64('Gw==') + '[1;36;49m',
+    `normal`     = '' + decode_base64('Gw==') + '[0m',
+    `boldRed`    = '' + decode_base64('Gw==') + '[1;31;49m',
+    `boldGreen`  = '' + decode_base64('Gw==') + '[1;32;49m',
+    `boldYellow` = '' + decode_base64('Gw==') + '[1;33;49m',
+    `boldCyan`   = '' + decode_base64('Gw==') + '[1;36;49m',
 )
 
 
@@ -340,7 +340,7 @@ describe('lspec command') => {
             // [dir->setCwd] can cause errors with lspec library, so
             // make sure to save off cwd first and set it back right after lspec call
             local(cwd)      = dir(io_file_getcwd)
-            local(expected) = error_code_resNotFound + ':' + error_msg_resNotFound + ' - ./spec/'
+            local(expected) = error_code_resNotFound + ':' + error_msg_resNotFound + ' - ./spec/' + sys_eol
             
             sys_process('/bin/rm', (:'-rf', #test_dir->path + 'spec/'))->wait
             
@@ -498,7 +498,7 @@ describe('lspec command') => {
             expect(void == #stderr)
             expect(#stdout->asString->contains(#expected))
         }
-        it(`doesn't colorize pending tests'`) => {
+        it(`doesn't colorize pending tests`) => {
             local(expected) = regexp(
                 "\\*\n\nPending:\n\n    1\\) pending test pends\n           # 1:31 //tmp/lspec.test.pend\n\n" +
                 `Finished in [0-9.]+ seconds` + "\n1 test, 0 failures, 1 pending"

--- a/spec/command/lspec.spec.inc
+++ b/spec/command/lspec.spec.inc
@@ -493,7 +493,12 @@ describe('lspec command') => {
             expect(#stdout->asString->contains(#expected))
         }
         it(`doesn't colorize failing tests`) => {
-            local(expected) = regexp("\\.\n\n" + `Finished in [0-9.]+ seconds` + "\n1 test, 0 failures")
+            local(expected) = regexp(
+                "F\n\nFailures:\n\n    1\\) failing test fails\n       Failure/Error: expect\\(false\\) \\} \\}\n" +
+                "           expected: true\n                got: false\n       # 1:48 //tmp/lspec\\.test\\.fail\n\n" +
+                `Finished in [0-9.]+ seconds` + "\n1 test, 1 failure"
+            )
+            local(stdout, stderr) = call_lspec((:'-nocolor', #file_testFail->path))
 
             expect(void == #stderr)
             expect(#stdout->asString->contains(#expected))
@@ -509,5 +514,66 @@ describe('lspec command') => {
             expect(#stdout->asString->contains(#expected))
         }
     }
-}
 
+    context('called with the -documentation argument') => {
+        local(file_testPass) = file('//tmp/lspec.test.pass')
+        local(file_testFail) = file('//tmp/lspec.test.fail')
+        local(file_testPend) = file('//tmp/lspec.test.pend')
+        beforeAll => {
+            #file_testPass->doWithClose => {
+                #file_testPass->openTruncate&writeString("\
+                    describe('passing test') => { it('passes') => { expect(true) } }\
+                ")
+            }
+            #file_testFail->doWithClose => {
+                #file_testFail->openTruncate&writeString("\
+                    describe('failing test') => { it('fails') => { expect(false) } }\
+                ")
+            }
+            #file_testPend->doWithClose => {
+                #file_testPend->openTruncate&writeString("\
+                    describe('pending test') => { it('pends') => { } }\
+                ")
+            }
+        }
+        afterAll => {
+            #file_testPass->delete
+            #file_testFail->delete
+            #file_testPend->delete
+        }
+        it(`prints names of passing tests`) => {
+            local(expected) = regexp("passing test\n    passes\n\n" + `Finished in [0-9.]+ seconds`)
+            local(stdout, stderr) = call_lspec((:'-documentation', #file_testPass->path))
+
+            expect(void == #stderr)
+            expect(#stdout->asString->contains(#expected))
+        }
+        it(`prints names of failing tests`) => {
+            local(expected) = regexp(
+                "failing test\n    fails \\(FAILED - 1\\)\n\n" +
+                string_replace($termColor('boldRed'), -find=`[`, -replace=`\[`) + "Failures:" +
+                string_replace($termColor('normal'), -find=`[`, -replace=`\[`) + "\n\n" +
+                "    1\\) failing test fails\n       Failure/Error: expect\\(false\\) \\} \\}\n" +
+                "           expected: true\n                got: false\n       # 1:48 //tmp/lspec\\.test\\.fail\n\n" +
+                `Finished in [0-9.]+ seconds`
+            )
+            local(stdout, stderr) = call_lspec((:'-documentation', #file_testFail->path))
+
+            expect(void == #stderr)
+            expect(#stdout->asString->contains(#expected))
+        }
+        it(`prints names of pending tests`) => {
+            local(expected) = regexp(
+                "pending test\n    pends\n\n" +
+                string_replace($termColor('boldYellow'), -find=`[`, -replace=`\[`) + "Pending:" +
+                string_replace($termColor('normal'), -find=`[`, -replace=`\[`) + "\n\n" +
+                "    1\\) pending test pends\n           # 1:31 //tmp/lspec.test.pend\n\n" +
+                `Finished in [0-9.]+ seconds`
+            )
+            local(stdout, stderr) = call_lspec((:'-documentation', #file_testPend->path))
+
+            expect(void == #stderr)
+            expect(#stdout->asString->contains(#expected))
+        }
+    }
+}

--- a/spec/command/lspec.spec.inc
+++ b/spec/command/lspec.spec.inc
@@ -12,7 +12,7 @@ define call_lspec(args::staticarray=(:)) => {
     local(my_process) = sys_process
     
     handle => {#my_process->close}
-    #my_process->open($lspec_path, #args)
+    #my_process->open($lspec_path, #args, (:'PATH='+sys_getenv('PATH')))
     #my_process->wait
     #stdout = #my_process->read
     #stderr = #my_process->readError

--- a/tests/lspec.test.inc
+++ b/tests/lspec.test.inc
@@ -4,7 +4,7 @@ not #path_here->endsWith('/') ? #path_here += '/'
 local(f) = file(#path_here + '../lspec.inc')
 sourcefile(#f->readString, #f->path, false, false)->invoke
 
-// [try] method: Based on code from Bil Corey
+// [try] method: Based on code from Bil Corry
 define try => {
     local(err) = null
     local(gb)  = givenBlock
@@ -23,11 +23,11 @@ define lspec_setupForTesting => {
 }
 
 var(termColor) = map(
-		`normal`     = '' + decode_base64('Gw==') + '[0m',
-		`boldRed`    = '' + decode_base64('Gw==') + '[1;31;49m',
-		`boldGreen`  = '' + decode_base64('Gw==') + '[1;32;49m',
-		`boldYellow` = '' + decode_base64('Gw==') + '[1;33;49m',
-		`boldCyan`   = '' + decode_base64('Gw==') + '[1;36;49m',
+    `normal`     = '' + decode_base64('Gw==') + '[0m',
+    `boldRed`    = '' + decode_base64('Gw==') + '[1;31;49m',
+    `boldGreen`  = '' + decode_base64('Gw==') + '[1;32;49m',
+    `boldYellow` = '' + decode_base64('Gw==') + '[1;33;49m',
+    `boldCyan`   = '' + decode_base64('Gw==') + '[1;36;49m',
 )
 
 

--- a/tests/lspec_core.test.inc
+++ b/tests/lspec_core.test.inc
@@ -578,7 +578,7 @@ describe("Something") => {
 }
 local(expected) = '\n\nFailures:\n
 ' + lspec->indentor + '1) Something does something
-' + lspec->indentor + '   Failure/Error: Unexpcted Error!
+' + lspec->indentor + '   Failure/Error: Unexpected Error!
 ' + lspec->indentor + '   ' + lspec->indentor + 'Error Code: ' + error_code_divideByZero + '
 ' + lspec->indentor + '   ' + lspec->indentor + ' Error Msg: ' + error_msg_divideByZero + '
 ' + lspec->indentor + '   # 574:5 ' + currentCapture->callsite_file

--- a/tests/lspec_expectations.test.inc
+++ b/tests/lspec_expectations.test.inc
@@ -840,7 +840,7 @@ if(lspec->numFailures != 1) => {
 }
 local(expected) = '\n\nFailures:\n
 ' + lspec->indentor + '1) Something Does something
-' + lspec->indentor + '   Failure/Error: Unexpcted Error!
+' + lspec->indentor + '   Failure/Error: Unexpected Error!
 ' + lspec->indentor + '   ' + lspec->indentor + 'Error Code: ' + error_code_divideByZero + '
 ' + lspec->indentor + '   ' + lspec->indentor + ' Error Msg: ' + error_msg_divideByZero + '
 ' + lspec->indentor + '   # 804:5 ' + currentCapture->callsite_file

--- a/tests/lspec_testGroup.test.inc
+++ b/tests/lspec_testGroup.test.inc
@@ -12,7 +12,7 @@ if(lspec->suite->first->numTests != 2) => {
 
 
 
-#test_desc = "[describe] sub-test groups properly handled at the end of tests & outputed correctly"
+#test_desc = "[describe] sub-test groups properly handled at the end of tests & outputted correctly"
 lspec_setupForTesting
 var(flag1 = false, flag2 = false)
 describe("Something") => {
@@ -53,7 +53,7 @@ if(lspec->suite->first->numTests != 2) => {
 
 
 
-#test_desc = "[context] sub-test groups properly handled at the end of tests & outputed correctly"
+#test_desc = "[context] sub-test groups properly handled at the end of tests & outputted correctly"
 lspec_setupForTesting
 var(flag1 = false, flag2 = false)
 context("Something") => {


### PR DESCRIPTION
Maintains compatibility with Lasso 9.2. Also has some spelling and grammar fixes and adds some additional self-testing.
The makefile now uses whatever macOS SDK is primary, to allow building to work out of the box.